### PR TITLE
Missing OWNER_ID on env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ CLIENT_ID=your_bot_client_id_here
 
 # Database Configuration
 DATABASE_URL=mysql://username:password@localhost:3306/sampbot
+
+# Owner configuration
+OWNER_ID=your_discord_user_id_here


### PR DESCRIPTION
Adds missing `OWNER_ID` var to .env.example